### PR TITLE
Refacto: SPRegistry -> FranchiseRegistry | SPFranchiseNFT -> StoryBl…

### DIFF
--- a/contracts/FranchiseRegistry.sol
+++ b/contracts/FranchiseRegistry.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import { IStoryBlockAware } from "./IStoryBlockAware.sol";
-import { SPFranchiseNFTFactory } from "./franchises/SPFranchiseNFTFactory.sol";
+import { StoryBlocksRegistryFactory } from "./franchises/StoryBlocksRegistryFactory.sol";
 import { AccessControlled } from "./access-control/AccessControlled.sol";
 import { UPGRADER_ROLE } from "./access-control/ProtocolRoles.sol";
 import { ZeroAddress } from "./errors/General.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { ERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
-contract SPRegistry is UUPSUpgradeable, AccessControlled, ERC721Upgradeable, IStoryBlockAware {
+contract FranchiseRegistry is UUPSUpgradeable, AccessControlled, ERC721Upgradeable, IStoryBlockAware {
 
     error AlreadyRegistered();
 
@@ -17,7 +17,7 @@ contract SPRegistry is UUPSUpgradeable, AccessControlled, ERC721Upgradeable, ISt
     // Franchise id => Collection address
     mapping(uint256 => address) public _franchises;
 
-    SPFranchiseNFTFactory public immutable FACTORY;
+    StoryBlocksRegistryFactory public immutable FACTORY;
     uint256 public constant PROTOCOL_ROOT_ID = 0;
     address public constant PROTOCOL_ROOT_ADDRESS = address(0);
 
@@ -25,7 +25,7 @@ contract SPRegistry is UUPSUpgradeable, AccessControlled, ERC721Upgradeable, ISt
     constructor(address _factory) {
         _disableInitializers();
         if (_factory == address(0)) revert ZeroAddress("factory");
-        FACTORY = SPFranchiseNFTFactory(_factory);
+        FACTORY = StoryBlocksRegistryFactory(_factory);
     }
 
     function initialize(address accessControl) public initializer {

--- a/contracts/franchises/IStoryBlocksRegistry.sol
+++ b/contracts/franchises/IStoryBlocksRegistry.sol
@@ -11,6 +11,6 @@ import { IERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ER
  * @author 
  * @notice WARNING: Non upgradeable contract, but part of the Beacon
  */
-interface ISPFranchiseNFT is IVersioned, IERC165Upgradeable, IERC721Upgradeable, IStoryBlockAware {
+interface IStoryBlocksRegistry is IVersioned, IERC165Upgradeable, IERC721Upgradeable, IStoryBlockAware {
     function mint(address to, StoryBlock sb) external;
 }

--- a/contracts/franchises/StoryBlocksRegistry.sol
+++ b/contracts/franchises/StoryBlocksRegistry.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import { ISPFranchiseNFT } from "./ISPFranchiseNFT.sol";
+import { IStoryBlocksRegistry } from "./IStoryBlocksRegistry.sol";
 import { IStoryBlockAware } from "../IStoryBlockAware.sol";
 import { Unauthorized, ZeroAddress } from "../errors/General.sol";
 import { ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import { IERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 
-contract SPFranchiseNFT is ISPFranchiseNFT, ERC721Upgradeable {
+contract StoryBlocksRegistry is IStoryBlocksRegistry, ERC721Upgradeable {
 
     event StoryBlockMinted(address indexed to, StoryBlock indexed sb, uint256 indexed tokenId);
 
@@ -89,7 +89,7 @@ contract SPFranchiseNFT is ISPFranchiseNFT, ERC721Upgradeable {
         returns (bool)
     {
         return
-            interfaceId == type(ISPFranchiseNFT).interfaceId ||
+            interfaceId == type(IStoryBlocksRegistry).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/franchises/StoryBlocksRegistryFactory.sol
+++ b/contracts/franchises/StoryBlocksRegistryFactory.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import { ISPFranchiseNFT } from "./ISPFranchiseNFT.sol";
-import { SPFranchiseNFT } from "./SPFranchiseNFT.sol";
+import { IStoryBlocksRegistry } from "./IStoryBlocksRegistry.sol";
+import { StoryBlocksRegistry } from "./StoryBlocksRegistry.sol";
 import { ZeroAddress } from "../errors/General.sol";
 import { IVersioned } from "../utils/IVersioned.sol";
 import { UnsupportedInterface } from "../errors/General.sol";
@@ -13,7 +13,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 
 
-contract SPFranchiseNFTFactory is Ownable {
+contract StoryBlocksRegistryFactory is Ownable {
     using ERC165Checker for address;
 
     event FranchiseCreated(address indexed collection, string name, string indexed symbol);
@@ -22,7 +22,7 @@ contract SPFranchiseNFTFactory is Ownable {
     UpgradeableBeacon public immutable BEACON;
 
     constructor() {
-        BEACON = new UpgradeableBeacon(address(new SPFranchiseNFT()));
+        BEACON = new UpgradeableBeacon(address(new StoryBlocksRegistry()));
     }
 
     function createFranchise(
@@ -42,7 +42,7 @@ contract SPFranchiseNFTFactory is Ownable {
     }
 
     function upgradeFranchises(address newImplementation) external onlyOwner {
-        if (!newImplementation.supportsInterface(type(ISPFranchiseNFT).interfaceId)) revert UnsupportedInterface("ISPFranchiseNFT");
+        if (!newImplementation.supportsInterface(type(IStoryBlocksRegistry).interfaceId)) revert UnsupportedInterface("IStoryBlocksRegistry");
         BEACON.upgradeTo(newImplementation);
         emit FranchisesUpgraded(address(newImplementation), IVersioned(newImplementation).version());
     }

--- a/test/foundry/FranchiseRegistry.t.sol
+++ b/test/foundry/FranchiseRegistry.t.sol
@@ -3,22 +3,22 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import './utils/ProxyHelper.sol';
-import "../../contracts/SPRegistry.sol";
+import "../../contracts/FranchiseRegistry.sol";
 import "../../contracts/access-control/AccessControlSingleton.sol";
-import "../../contracts/franchises/SPFranchiseNFTFactory.sol";
+import "../../contracts/franchises/StoryBlocksRegistryFactory.sol";
 
-contract SPRegistryTest is Test, ProxyHelper {
-    SPFranchiseNFTFactory public factory;
-    SPRegistry public register;
+contract FranchiseRegistryTest is Test, ProxyHelper {
+    StoryBlocksRegistryFactory public factory;
+    FranchiseRegistry public register;
 
     address admin;
 
     function setUp() public {
-        factory = new SPFranchiseNFTFactory();
+        factory = new StoryBlocksRegistryFactory();
         address accessControl = address(new AccessControlSingleton());
         
-        SPRegistry impl = new SPRegistry(address(factory));
-        register = SPRegistry(
+        FranchiseRegistry impl = new FranchiseRegistry(address(factory));
+        register = FranchiseRegistry(
             _deployUUPSProxy(
                 address(impl),
                 abi.encodeWithSelector(

--- a/test/foundry/StoryBlocksRegistry.t.sol
+++ b/test/foundry/StoryBlocksRegistry.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSDL-1.1
 pragma solidity ^0.8.13;
 
-import { SPFranchiseNFT } from "../../contracts/franchises/SPFranchiseNFT.sol";
-import { SPFranchiseNFTFactory } from "../../contracts/franchises/SPFranchiseNFTFactory.sol";
+import { StoryBlocksRegistry } from "../../contracts/franchises/StoryBlocksRegistry.sol";
+import { StoryBlocksRegistryFactory } from "../../contracts/franchises/StoryBlocksRegistryFactory.sol";
 import { IStoryBlockAware } from "../../contracts/IStoryBlockAware.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { IERC1967 } from "@openzeppelin/contracts/interfaces/IERC1967.sol";
 import "forge-std/Test.sol";
 
-contract SPFranchiseNFTTest is Test, IStoryBlockAware {
+contract StoryBlocksRegistryTest is Test, IStoryBlockAware {
     using stdStorage for StdStorage;
 
     event CollectionCreated(address indexed collection, string name, string indexed symbol);
@@ -18,8 +18,8 @@ contract SPFranchiseNFTTest is Test, IStoryBlockAware {
 
     error IdOverBounds();
 
-    SPFranchiseNFTFactory public factory;
-    SPFranchiseNFT public franchise;
+    StoryBlocksRegistryFactory public factory;
+    StoryBlocksRegistry public franchise;
     address owner = address(this);
     address mintee = address(1);
 
@@ -32,8 +32,8 @@ contract SPFranchiseNFTTest is Test, IStoryBlockAware {
     uint256 private constant _LAST_ID = _ID_RANGE + _FIRST_ID_LOCATION;
 
     function setUp() public {
-        factory = new SPFranchiseNFTFactory();
-        franchise = SPFranchiseNFT(factory.createFranchise("name", "symbol", "description"));
+        factory = new StoryBlocksRegistryFactory();
+        franchise = StoryBlocksRegistry(factory.createFranchise("name", "symbol", "description"));
     }
 
     function test_setUp() public {

--- a/test/foundry/StoryBlocksRegistryFactory.t.sol
+++ b/test/foundry/StoryBlocksRegistryFactory.t.sol
@@ -2,34 +2,34 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "../../contracts/franchises/SPFranchiseNFTFactory.sol";
+import "../../contracts/franchises/StoryBlocksRegistryFactory.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { IERC1967 } from "@openzeppelin/contracts/interfaces/IERC1967.sol";
 
-contract SPFranchiseNFTv2 is SPFranchiseNFT {
+contract StoryBlocksRegistryv2 is StoryBlocksRegistry {
     function version() virtual override external pure returns (string memory) {
         return "2.0.0";
     }
 }
 
-contract SPFranchiseNFTFactoryTest is Test {
+contract StoryBlocksRegistryFactoryTest is Test {
 
     event FranchiseCreated(address indexed collection, string name, string indexed symbol);
     event FranchisessUpgraded(address indexed newImplementation, string version);
     event BeaconUpgraded(address indexed beacon);
 
     address notOwner = address(0x123);
-    SPFranchiseNFTFactory public factory;
+    StoryBlocksRegistryFactory public factory;
 
     function setUp() public {
-        factory = new SPFranchiseNFTFactory();
+        factory = new StoryBlocksRegistryFactory();
     }
 
     function test_Contructor() public {
         assertTrue(address(factory.BEACON()) != address(0));
         UpgradeableBeacon beacon = factory.BEACON();
         assertTrue(address(beacon.implementation()) != address(0));
-        assertEq(SPFranchiseNFT(beacon.implementation()).version(), "0.1.0");
+        assertEq(StoryBlocksRegistry(beacon.implementation()).version(), "0.1.0");
     }
 
     function test_CreateFranchise() public {
@@ -40,21 +40,21 @@ contract SPFranchiseNFTFactoryTest is Test {
         // emit BeaconUpgraded(address(0x123));
         address collection = factory.createFranchise("name", "symbol", "description");
         assertTrue(collection != address(0));
-        assertEq(SPFranchiseNFT(collection).name(), "name");
-        assertEq(SPFranchiseNFT(collection).symbol(), "symbol");
+        assertEq(StoryBlocksRegistry(collection).name(), "name");
+        assertEq(StoryBlocksRegistry(collection).symbol(), "symbol");
     }
 
     function test_UpgradeCollections() public {
-        SPFranchiseNFTv2 newImplementation = new SPFranchiseNFTv2();
+        StoryBlocksRegistryv2 newImplementation = new StoryBlocksRegistryv2();
         //vm.expectEmit(true, true, true, true);
         //emit CollectionsUpgraded(address(newImplementation), "2.0.0");
         factory.upgradeFranchises(address(newImplementation));
         UpgradeableBeacon beacon = factory.BEACON();
-        assertEq(SPFranchiseNFT(beacon.implementation()).version(), "2.0.0");
+        assertEq(StoryBlocksRegistry(beacon.implementation()).version(), "2.0.0");
     }
 
     function test_revertIfNotOwnerUpgrades() public {
-        SPFranchiseNFTv2 newImplementation = new SPFranchiseNFTv2();
+        StoryBlocksRegistryv2 newImplementation = new StoryBlocksRegistryv2();
         vm.prank(notOwner);
         vm.expectRevert("Ownable: caller is not the owner");
         factory.upgradeFranchises(address(newImplementation));


### PR DESCRIPTION
Main registry actually registers Franchises, so name it accordingly.
SPFranchiseNFT actually registers Story Blocks for the franchise, so name it accordingly.
We are also dropping NFT from the contract names. Registry already implies it.