### PR TITLE
Adds standard collect events

### DIFF
--- a/contracts/interfaces/modules/collect/ICollectModule.sol
+++ b/contracts/interfaces/modules/collect/ICollectModule.sol
@@ -7,6 +7,26 @@ import { Collect } from "contracts/lib/modules/Collect.sol";
 /// @notice The collect module enables IP assets to be minted as NFTs mirroring
 ///         their binding IP assets in a franchise-configurable format.
 interface ICollectModule {
+
+    /// @dev Emits when a Collect action is invoked.
+    /// TODO: Once global IPs are supported, we can index the collect NFTs as well.
+    event Collected(
+        uint256 indexed franchiseid_,
+        uint256 indexed ipAssetId_,
+        address indexed collector_,
+        address collectNft_,
+        uint256 collectNftId_,
+        bytes collectData_,
+        bytes collectNftData_
+    );
+
+    /// @dev Emits when a new collect NFT is deployed.
+    event NewCollectNFT(
+        uint256 indexed franchiseId_,
+        uint256 indexed ipAssetId_,
+        address collectNFT_
+    );
+
     /// @notice Initializes the collect module for a specific IP asset.
     /// @param initCollectParams_ Collect module init data, including IP   asset
     ///        id, collect NFT impl address, and generic unformatted init data.

--- a/contracts/modules/collect/CollectModuleBase.sol
+++ b/contracts/modules/collect/CollectModuleBase.sol
@@ -127,6 +127,17 @@ abstract contract CollectModuleBase is AccessControlledUpgradeable, ICollectModu
         // Perform any additional collect module processing.
         _collect(collectParams_);
 
+        // Emit the Collect event.
+        emit Collected(
+            franchiseId,
+            ipAssetId,
+            collectParams_.collector,
+            collectNft,
+            collectNftId,
+            collectParams_.collectData,
+            collectParams_.collectNftData
+        );
+
         return (collectNft, collectNftId);
     }
 
@@ -174,6 +185,9 @@ abstract contract CollectModuleBase is AccessControlledUpgradeable, ICollectModu
                 data: initData_
             }));
             $.collectInfo[franchiseId_][ipAssetId_].collectNft = collectNft;
+
+            // Emit the event indicating a new Collect NFT was created.
+            emit NewCollectNFT(franchiseId_, ipAssetId_, collectNft);
         }
         return collectNft;
     }


### PR DESCRIPTION
Fixes #85 by adding two standard Collect events:

One for invocation of the Collect action:
```
    event Collected(
        uint256 indexed franchiseid_,
        uint256 indexed ipAssetId_,
        address indexed collector_,
        address collectNft_,
        uint256 collectNftId_,
        bytes collectData_,
        bytes collectNftData_
    );
```
    
And one for deploying a new Collect NFT:
```
    /// @dev Emits when a new collect NFT is deployed.
    event NewCollectNFT(
        uint256 indexed franchiseId_,
        uint256 indexed ipAssetId_,
        address collectNFT_
    );
```