### PR TITLE
[Github Action] Loading MAINNET PPC URL from Github secret

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           echo "MAINNET_RPC_URL is ${{ secrets.MAINNET_RPC_URL }}"
           echo "env.MAINNET_RPC_URL is $MAINNET_RPC_URL"
           echo "env.FOUNDRY_PROFILE is $FOUNDRY_PROFILE"
+          echo "DONE."
 
       - name: Run install
         uses: borales/actions-yarn@v4


### PR DESCRIPTION
Github workflow requires using MAINNET_RPC.
We should protect the Mainnet RPC URL as Github secret.
Then load the secret in Github unit test action.

Closes #136