### PR TITLE
Adding support register IP Asset with user defined tokenURI

### DIFF
--- a/contracts/interfaces/modules/registration/IRegistrationModule.sol
+++ b/contracts/interfaces/modules/registration/IRegistrationModule.sol
@@ -24,6 +24,7 @@ interface IRegistrationModule {
     /// @param name_ The name of the IP asset being registered.
     /// @param ipAssetType_ The numerical id of the IP asset type.
     /// @param hash_ The content hash of the registered IP asset.
+    /// @param mediaUrl_ The media URL of the registered IP asset.
     event IPAssetRegistered(
         uint256 ipAssetId_,
         address indexed ipOrg_,
@@ -31,7 +32,8 @@ interface IRegistrationModule {
         address indexed owner_,
         string name_,
         uint64 indexed ipAssetType_,
-        bytes32 hash_
+        bytes32 hash_,
+        string mediaUrl_
     );
 
     /// @notice Emits when an IP asset is transferred to a new owner.

--- a/contracts/lib/IPAsset.sol
+++ b/contracts/lib/IPAsset.sol
@@ -38,6 +38,7 @@ library IPAsset {
         uint64 ipAssetType;
         address owner;
         bytes32 hash;
+        string mediaUrl;
     }
 
     struct CreateIpAssetParams {

--- a/contracts/lib/modules/Registration.sol
+++ b/contracts/lib/modules/Registration.sol
@@ -17,6 +17,7 @@ library Registration {
         string name;
         uint64 ipAssetType;
         bytes32 hash;
+        string mediaUrl;
     }
 
     // TODO(leeren): Change in favor of granular function-selector based auth.

--- a/test/foundry/modules/registration/RegistrationTest.sol
+++ b/test/foundry/modules/registration/RegistrationTest.sol
@@ -34,7 +34,8 @@ contract RegistrationModuleTest is BaseTest {
         address indexed owner_,
         string name_,
         uint64 indexed ipAssetType_,
-        bytes32 hash_
+        bytes32 hash_,
+        string mediaUrl_
     );
 
     // Id of IP asset which may differ per test based on testing constraints.
@@ -116,11 +117,42 @@ contract RegistrationModuleTest is BaseTest {
             cal,
             "TestIPA",
             0,
+            "",
             ""
         );
-        _register(address(ipOrg), cal, "TestIPA", 0, "");
+        _register(address(ipOrg), cal, "TestIPA", 0, "", "");
         assertEq(registry.ipAssetOwner(0), cal);
         assertEq(ipOrg.ownerOf(0), cal);
+    }
+
+    /// @notice Tests IP Asset registration with media URL.
+    function test_RegistrationModuleIPARegistrationWithMediaUrl() public virtual {
+        string memory mediaUrl = "http://token.url";
+        vm.prank(cal);
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit Registered(
+            0,
+            "TestIPA",
+            0,
+            address(ipOrg),
+            cal,
+            ""
+        );
+        vm.expectEmit(true, true, true, true, address(registrationModule));
+        emit IPAssetRegistered(
+            0,
+            address(ipOrg),
+            0,
+            cal,
+            "TestIPA",
+            0,
+            "",
+            mediaUrl
+        );
+        _register(address(ipOrg), cal, "TestIPA", 0, "", mediaUrl);
+        assertEq(registry.ipAssetOwner(0), cal);
+        assertEq(ipOrg.ownerOf(0), cal);
+        assertEq(mediaUrl, registrationModule.tokenURI(address(ipOrg), 0));
     }
 
     /// @dev Helper function that performs registration.
@@ -134,13 +166,15 @@ contract RegistrationModuleTest is BaseTest {
         address owner_,
         string memory name_,
         uint64 ipAssetType_,
-        bytes32 hash_
+        bytes32 hash_,
+        string memory mediaUrl_
     ) internal virtual returns (uint256, uint256) {
         Registration.RegisterIPAssetParams memory params = Registration.RegisterIPAssetParams({
             owner: owner_,
             name: name_,
             ipAssetType: ipAssetType_, 
-            hash: hash_
+            hash: hash_,
+            mediaUrl: mediaUrl_
         });
         bytes[] memory hooks = new bytes[](0);
         return spg.registerIPAsset(address(ipOrg), params, hooks, hooks);

--- a/test/foundry/utils/BaseTest.sol
+++ b/test/foundry/utils/BaseTest.sol
@@ -165,7 +165,8 @@ contract BaseTest is BaseTestUtils, ProxyHelper, AccessControlHelper {
             owner: ipAssetOwner,
             name: "TestIPAsset",
             ipAssetType: 0, 
-            hash: ""
+            hash: "",
+            mediaUrl: ""
         });
         bytes[] memory hooks = new bytes[](0);
         (uint256 globalId, uint256 localId) = spg.registerIPAsset(address(ipOrg), params, hooks, hooks);


### PR DESCRIPTION
### Summary
Currently, the tokenURI method concatenates a baseURI with the tokenID to generate the URI for a token. This approach is not suitable when using a decentralized database like Arweave or IPFS, where the URIs are not predictable and cannot be generated by simply appending the tokenID to a baseURI.

### Change
Updated the tokenURI method in the RegistrationModule contract to support user-defined URIs. 

### Tests
Added new test case to verify the user-defined URI would be returned by tokenURI method in the RegistrationModule, if user provide the medataURL when registering the IP Asset.

Closes #180 