### PR TITLE
Introduce solidity-docgen in the project for generating documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,24 @@ make slither
 
 And get your slither output.
 
+# Document Generation
+
+We use [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen) to generate the documents for smart contracts. Documents can be generated with the following command:
+
+```
+npx hardhat docgen
+```
+
+By default, the documents are generated in Markdown format in the `doc` folder of the project. Each Solidity file (`*.sol`) has its own Markdown (`*.md`) file. To update the configuration for document generation, you can update the following section in `harhat.config.js`:
+
+```
+docgen: {
+  outputDir: "./docs",
+  pages: "files"
+}
+```
+
+You can refer to the [config.ts](https://github.com/OpenZeppelin/solidity-docgen/blob/master/src/config.ts) of solidity-docgen for the full list of configurable parameters.
 
 ## Resources
 -   [Hardhat](https://hardhat.org/docs)

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -8,6 +8,7 @@ require("solidity-coverage");
 require('@nomiclabs/hardhat-ethers');
 require("@nomiclabs/hardhat-etherscan");
 require('@openzeppelin/hardhat-upgrades');
+require('solidity-docgen');
 
 const createFranchise = require("./script/hardhat/createFranchise.js");
 const createIPAsset = require("./script/hardhat/createIPAsset.js");
@@ -126,5 +127,9 @@ module.exports = {
   },
   mocha: {
     timeout: 20000
+  },
+  docgen: {
+    outputDir: "./docs",
+    pages: "files"
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "prettier-plugin-solidity": "^1.1.3",
     "solhint": "^3.6.2",
     "solhint-plugin-prettier": "^0.0.5",
-    "solidity-coverage": "^0.8.2"
+    "solidity-coverage": "^0.8.2",
+    "solidity-docgen": "^0.6.0-beta.36"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.3",


### PR DESCRIPTION
This PR add solidity-docgen for generating the documents for solidity files. See `README.md` for instruction for generating docs.

Closes #201 