### PR TITLE
Remove 'indexed' from string relType events

### DIFF
--- a/contracts/interfaces/modules/relationships/IRelationshipModule.sol
+++ b/contracts/interfaces/modules/relationships/IRelationshipModule.sol
@@ -9,7 +9,7 @@ interface IRelationshipModule {
     /// Emitted with a new Relationship Type definitions is created
     event RelationshipTypeSet(
         // Short string naming the type
-        string indexed relType,
+        string relType,
         // Zero for protocol-wide, or address of the IPOrg
         address indexed ipOrg,
         // Allowed src address, zero address if empty, all F for all addresses are OK
@@ -29,7 +29,7 @@ interface IRelationshipModule {
     /// Emitted when a Relationship Type definition is removed
     event RelationshipTypeUnset(
         // Short string naming the type
-        string indexed relType,
+        string relType,
         // Zero for protocol-wide, or address of the IPOrg
         address ipOrg
     );
@@ -39,7 +39,7 @@ interface IRelationshipModule {
         // Sequential Relationship ID
         uint256 indexed relationshipId,
         // Short string naming the type
-        string indexed relType,
+        string relType,
         // Source contract or EOA
         address srcAddress,
         // Source item ID


### PR DESCRIPTION
The changes modify `string indexed relType` to `string relType` per #208.

A note on `string indexed` vs. `string` in events (from [SO](https://ethereum.stackexchange.com/a/7170)):
All event arguments with the `indexed` prefix are stored in `topics` while non-indexed args are stored in the `data` section of the transaction receipt. Since the string is of arbitrary length, Solidity hashes (keccak256) indexed string arguments and stores the hashes in the events. So filtering for `string indexed relType` in logs is filtering for strings of max size 32 bytes (to fit in bytes32) (= 32 letters), which means longer `relType` strings will get pruned with the `indexed` prefix.

Consideration: Can't search indexed relType anymore.
Potential solution: Have 32-letter unique ID for each relType (the mapping of ID to relType is stored off-chain), emit relType as normal string and the unique ID as indexed bytes32. Filter on unique ID based on the mapping stored off-chain.