### PR TITLE
Introducing PolygonTokenHook: An Asynchronous Hook for Verifying Polygon Token Ownership

### DIFF
--- a/contracts/hooks/PolygonTokenHook.sol
+++ b/contracts/hooks/PolygonTokenHook.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { HookResult } from "contracts/interfaces/hooks/base/IHook.sol";
+import { AsyncBaseHook } from "contracts/hooks/base/AsyncBaseHook.sol";
+import { Errors } from "contracts/lib/Errors.sol";
+import { PolygonToken } from "contracts/lib/hooks/PolygonToken.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title PolygonTokenHook
+/// @notice This is asynchronous hook used to verify a user owning specific Polygon tokens.
+contract PolygonTokenHook is AsyncBaseHook {
+    /// @notice The address that is allowed to call the callback function.
+    /// @dev This address is set during contract deployment and cannot be changed afterwards.
+    address private immutable CALLBACK_CALLER;
+
+    /// @notice A counter used to generate unique request IDs for each token request.
+    uint256 private nonce;
+
+    /// @notice A mapping that links each request ID to a PolygonTokenRequest struct.
+    mapping(bytes32 => PolygonTokenRequest) private requestIdToRequest;
+
+    /// @notice A struct used to store information about a token request.
+    /// @dev It includes the requester's address, the token's address, the token owner's address, a balance threshold,
+    ///      and two boolean flags to indicate whether the request is completed and whether it exists.
+    struct PolygonTokenRequest {
+        address requester;
+        address tokenAddress;
+        address tokenOwnerAddress;
+        uint256 balanceThreshold;
+        bool isRequestCompleted;
+        bool exists;
+    }
+
+    /// @notice Emits an event for a Polygon token balance request.
+    /// @param requestId The unique ID of the request.
+    /// @param requester The address of the requester.
+    /// @param tokenAddress The address of the token.
+    /// @param tokenOwnerAddress The address of the token owner.
+    /// @param callbackAddr The address of the callback.
+    /// @param callbackFunctionSignature The signature of the callback function.
+
+    event PolygonTokenBalanceRequest(
+        bytes32 indexed requestId,
+        address indexed requester,
+        address tokenAddress,
+        address tokenOwnerAddress,
+        address callbackAddr,
+        bytes4 callbackFunctionSignature
+    );
+
+    /// @notice Initializes the contract during deployment.
+    /// @param accessControl_ The address of the access control contract.
+    /// @param callbackCaller_ The address of the callback caller contract.
+    constructor(
+        address accessControl_,
+        address callbackCaller_
+    ) AsyncBaseHook(accessControl_) {
+        if (callbackCaller_ == address(0)) revert Errors.ZeroAddress();
+        CALLBACK_CALLER = callbackCaller_;
+    }
+
+    /// @notice Handles the callback of a token request.
+    /// @param requestId The unique ID of the request.
+    /// @param balance The balance of the token.
+    function handleCallback(bytes32 requestId, uint256 balance) external {
+        bool isPassed = false;
+        string memory errorMessage = "";
+        require(requestIdToRequest[requestId].exists, "Request not found");
+        if (balance < requestIdToRequest[requestId].balanceThreshold) {
+            errorMessage = "Followers count is not enough";
+        } else {
+            isPassed = true;
+        }
+        delete requestIdToRequest[requestId];
+        _handleCallback(requestId, abi.encode(isPassed, errorMessage));
+    }
+
+    /// @notice Validates the configuration for the hook.
+    /// @dev This function checks if the tokenAddress and balanceThreshold in the configuration are valid.
+    ///      It reverts if the tokenAddress is the zero address or if the balanceThreshold is zero.
+    /// @param hookConfig_ The configuration data for the hook, encoded as bytes.
+    function _validateConfig(bytes memory hookConfig_) internal pure override {
+        PolygonToken.Config memory config = abi.decode(
+            hookConfig_,
+            (PolygonToken.Config)
+        );
+        if (config.tokenAddress == address(0)) {
+            revert Errors.Hook_InvalidHookConfig("tokenAddress is 0");
+        }
+        if (config.balanceThreshold == 0) {
+            revert Errors.Hook_InvalidHookConfig("balanceThreshold is 0");
+        }
+    }
+
+    /// @dev Internal function to request an asynchronous call,
+    /// concrete hoot implementation should override the function.
+    /// The function should revert in case of error.
+    /// @param hookConfig_ The configuration of the hook.
+    /// @param hookParams_ The parameters for the hook.
+    /// @return hookData The data returned by the hook.
+    /// @return requestId The ID of the request.
+    function _requestAsyncCall(
+        bytes memory hookConfig_,
+        bytes memory hookParams_
+    ) internal override returns (bytes memory hookData, bytes32 requestId) {
+        PolygonToken.Config memory config = abi.decode(
+            hookConfig_,
+            (PolygonToken.Config)
+        );
+        PolygonToken.Params memory params = abi.decode(
+            hookParams_,
+            (PolygonToken.Params)
+        );
+        requestId = keccak256(abi.encodePacked(this, nonce++));
+        hookData = "";
+
+        requestIdToRequest[requestId] = PolygonTokenRequest({
+            requester: msg.sender,
+            tokenAddress: config.tokenAddress,
+            tokenOwnerAddress: params.tokenOwnerAddress,
+            balanceThreshold: config.balanceThreshold,
+            isRequestCompleted: false,
+            exists: true
+        });
+
+        emit PolygonTokenBalanceRequest(
+            requestId,
+            msg.sender,
+            config.tokenAddress,
+            params.tokenOwnerAddress,
+            address(this),
+            this.handleCallback.selector
+        );
+    }
+
+    /// @notice Returns the address of the callback caller.
+    /// @param requestId The unique ID of the request.
+    /// @return The address of the callback caller.
+    function _callbackCaller(bytes32) internal view override returns (address) {
+        return CALLBACK_CALLER;
+    }
+}

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -40,7 +40,6 @@ library Errors {
 
     error BaseModule_HooksParamsLengthMismatch(uint8 hookType);
     error BaseModule_ZeroIpaRegistry();
-    error BaseModule_ZeroModuleRegistry();
     error BaseModule_ZeroLicenseRegistry();
     error BaseModule_OnlyModuleRegistry();
 
@@ -60,6 +59,8 @@ library Errors {
     error HookRegistry_HooksConfigLengthMismatch();
     /// @notice This error is thrown when the provided index is out of bounds of the hooks array.
     error HookRegistry_IndexOutOfBounds(uint256 hooksIndex);
+    error HookRegistry_ZeroModuleRegistry();
+
 
     ////////////////////////////////////////////////////////////////////////////
     //                      BaseRelationshipProcessor                         //
@@ -74,6 +75,7 @@ library Errors {
 
     error ModuleRegistry_ModuleNotRegistered(string moduleName);
     error ModuleRegistry_CallerNotOrgOwner();
+    error ModuleRegistry_HookNotRegistered(string hookKey);
 
     ////////////////////////////////////////////////////////////////////////////
     //                                 CollectModule                          //
@@ -402,6 +404,11 @@ library Errors {
 
     /// @notice The address is not the owner of the token.
     error TokenGatedHook_NotTokenOwner(address tokenAddress, address ownerAddress);
+
+    error Hook_AsyncHookError(bytes32 requestId, string reason);
+    
+    /// @notice Invalid Hook configuration.
+    error Hook_InvalidHookConfig(string reason);
 
     ////////////////////////////////////////////////////////////////////////////
     //                       LicensorApprovalHook                             //

--- a/contracts/lib/hooks/Hook.sol
+++ b/contracts/lib/hooks/Hook.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.19;
-
+import { IHook } from "contracts/interfaces/hooks/base/IHook.sol";
 /// @title Hook
 /// @notice This library defines the ExecutionContext struct used when executing hooks.
 /// @dev The ExecutionContext struct contains two fields: config and params, both of type bytes.
@@ -15,5 +15,15 @@ library Hook {
         /// @notice The parameters for the hook, encoded as bytes.
         /// @dev These parameters are passed from the external caller when executing modules.
         bytes params;
+    }
+
+    function canSupportSyncCall(IHook self) internal pure returns (bool) {
+        // TODO: return uint256(uint160(address(self))) & SYNC_FLAG != 0;
+        return true;
+    }
+
+    function canSupportAsyncCall(IHook self) internal pure returns (bool) {
+        // TODO:  return uint256(uint160(address(self))) & ASYNC_FLAG != 0;
+        return true;
     }
 }

--- a/contracts/lib/hooks/PolygonToken.sol
+++ b/contracts/lib/hooks/PolygonToken.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.19;
+
+/// @title TokenGated
+/// @notice This library defines the Config and Params structs used in the TokenGatedHook.
+/// @dev The Config struct contains the tokenAddress field, and the Params struct contains the tokenOwner field.
+library PolygonToken {
+    /// @notice Defines the required configuration information for the TokenGatedHook.
+    /// @dev The Config struct contains a single field: tokenAddress.
+    struct Config {
+        /// @notice The threshold of number of users who follow this user.
+        address tokenAddress;
+        /// @notice The threshold of number of lists that include this user.
+        uint256 balanceThreshold;
+    }
+
+    /// @notice Defines the required parameter information for executing the TokenGatedHook.
+    /// @dev The Params struct contains a single field: tokenOwner.
+    struct Params {
+        /// @notice The address of the token owner.
+        /// @dev This address is checked against the tokenAddress in the Config struct to ensure the owner has a token.
+        address tokenOwnerAddress;
+    }
+}

--- a/test/foundry/mocks/MockHookRegistry.sol
+++ b/test/foundry/mocks/MockHookRegistry.sol
@@ -3,22 +3,24 @@ pragma solidity ^0.8.18;
 
 import { HookRegistry } from "contracts/modules/base/HookRegistry.sol";
 import { IIPOrg } from "contracts/interfaces/ip-org/IIPOrg.sol";
+import { ModuleRegistry } from "contracts/modules/ModuleRegistry.sol";
 
 /// @title Mock Hook Registry
 /// @notice This mock contract is used for testing the base hook registry.
 contract MockHookRegistry is HookRegistry {
+    constructor(ModuleRegistry moduleRegistry_) HookRegistry(moduleRegistry_) {}
 
     function hookRegistryKey(
         address ipOrg_,
         string calldata someHookRegisteringRelatedInfo_
-    ) public pure returns(bytes32) {
+    ) public pure returns (bytes32) {
         return _generateRegistryKey(ipOrg_, someHookRegisteringRelatedInfo_);
     }
 
     function _generateRegistryKey(
         address ipOrg_,
         string memory someHookRegisteringRelatedInfo_
-    ) private pure returns(bytes32) {
+    ) private pure returns (bytes32) {
         return keccak256(abi.encode(ipOrg_, someHookRegisteringRelatedInfo_));
     }
 }

--- a/test/foundry/modules/base/BaseModule.t.sol
+++ b/test/foundry/modules/base/BaseModule.t.sol
@@ -55,7 +55,7 @@ contract BaseModuleTest is BaseTest {
 
     function test_baseModule_revert_constructorModuleRegistryIsZero() public {
         vm.prank(admin);
-        vm.expectRevert(Errors.BaseModule_ZeroModuleRegistry.selector);
+        vm.expectRevert(Errors.HookRegistry_ZeroModuleRegistry.selector);
         module = new MockBaseModule(
             admin,
             BaseModule.ModuleConstruction(

--- a/test/foundry/modules/base/HookRegistryTest.t.sol
+++ b/test/foundry/modules/base/HookRegistryTest.t.sol
@@ -22,7 +22,7 @@ contract HookRegistryTest is BaseTest {
         super.setUp();
 
         vm.prank(admin);
-        hookRegistry = new MockHookRegistry();
+        hookRegistry = new MockHookRegistry(moduleRegistry);
     }
 
     function test_hookRegistry_registerPreHooks() public {


### PR DESCRIPTION

This PR introduces a new asynchronous hook named PolygonTokenHook. This hook is used to verify a user owning specific Polygon tokens.
### Changes

- A new contract PolygonTokenHook is added which extends from AsyncBaseHook. This contract is initialized with the address of the access control contract and the address of the callback caller contract during deployment. The callback caller address is immutable and cannot be changed after deployment.
- The contract emits a PolygonTokenBalanceRequest event which includes the request ID, requester address, token address, token owner address, callback address, and callback function signature.
- The PolygonToken library is introduced, which defines the Config and Params structs used in the PolygonTokenHook.